### PR TITLE
Preventing NULL dereference

### DIFF
--- a/src/chips_stubs.c
+++ b/src/chips_stubs.c
@@ -1,24 +1,32 @@
 #include <fel.h>
 
-struct chip_t a10;
-struct chip_t a13_a10s_r8;
-struct chip_t a20;
-struct chip_t a23;
-struct chip_t a31;
-struct chip_t a33_r16;
-struct chip_t a40i_r40;
-struct chip_t a64;
-struct chip_t a80;
-struct chip_t a83t;
-struct chip_t d1_f133;
-struct chip_t h2_h3;
-struct chip_t h5;
-struct chip_t h6;
-struct chip_t h616;
-struct chip_t r328;
-struct chip_t r329;
-struct chip_t r528_t113;
-struct chip_t t507;
-struct chip_t v3s_s3;
-struct chip_t v536;
-struct chip_t v831;
+/* empty stubs need a non-NULL chip->detect pointer, as it's called by fel_init
+   while detecting chips */
+
+static int dummy_detect(struct xfel_ctx_t * ctx, uint32_t id)
+{
+    return 0;
+}
+
+struct chip_t a10          = { .detect = dummy_detect };
+struct chip_t a13_a10s_r8  = { .detect = dummy_detect };
+struct chip_t a20          = { .detect = dummy_detect };
+struct chip_t a23          = { .detect = dummy_detect };
+struct chip_t a31          = { .detect = dummy_detect };
+struct chip_t a33_r16      = { .detect = dummy_detect };
+struct chip_t a40i_r40     = { .detect = dummy_detect };
+struct chip_t a64          = { .detect = dummy_detect };
+struct chip_t a80          = { .detect = dummy_detect };
+struct chip_t a83t         = { .detect = dummy_detect };
+struct chip_t d1_f133      = { .detect = dummy_detect };
+struct chip_t h2_h3        = { .detect = dummy_detect };
+struct chip_t h5           = { .detect = dummy_detect };
+struct chip_t h6           = { .detect = dummy_detect };
+struct chip_t h616         = { .detect = dummy_detect };
+struct chip_t r328         = { .detect = dummy_detect };
+struct chip_t r329         = { .detect = dummy_detect };
+struct chip_t r528_t113    = { .detect = dummy_detect };
+struct chip_t t507         = { .detect = dummy_detect };
+struct chip_t v3s_s3       = { .detect = dummy_detect };
+struct chip_t v536         = { .detect = dummy_detect };
+struct chip_t v831         = { .detect = dummy_detect };

--- a/src/chips_stubs.c
+++ b/src/chips_stubs.c
@@ -1,3 +1,8 @@
+/* SPDX-License-Identifier: MIT
+ * Copyright 2025      Alex Volkov
+ * Copyright 2024      Jorenar
+ */
+
 #include <fel.h>
 
 /* empty stubs need a non-NULL chip->detect pointer, as it's called by fel_init

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: MIT
+ * Copyright 2025      Alex Volkov
  * Copyright 2024      Jorenar
  * Copyright 2022-2024 DavidAlfa
  */


### PR DESCRIPTION
As it is, the program segfaults at start, as `xfel` at device detection enumerates all the chips calling their `.detect` method, which leads to NULL dereference in initalized-by-default stubs. To prevent that, a dummy detect function was made.
